### PR TITLE
Add support for dynamic import statement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "escomplex-plugin-syntax-estree",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escomplex-plugin-syntax-estree",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/typhonjs-node-escomplex/escomplex-plugin-syntax-estree/",
   "description": "Provides a plugin for typhonjs-escomplex module processing which loads syntax definitions for trait resolution for ESTree AST.",
   "license": "MPL-2.0",

--- a/src/PluginSyntaxESTree.js
+++ b/src/PluginSyntaxESTree.js
@@ -211,6 +211,21 @@ export default class PluginSyntaxESTree extends AbstractSyntaxLoader
 
             return { line: node.loc.start.line, path: dependencyPath, type: 'cjs' };
          }
+
+         if (node.callee.type === 'Import' && node.arguments.length === 1)
+         {
+            const dependency = node.arguments[0];
+
+            let dependencyPath = '* dynamic dependency *';
+
+            if (dependency.type === 'Literal' || dependency.type === 'StringLiteral')
+            {
+               dependencyPath = typeof settings.dependencyResolver === 'function' ?
+                settings.dependencyResolver(dependency.value) : dependency.value;
+            }
+
+            return { line: node.loc.start.line, path: dependencyPath, type: 'esm' };
+         }
       });
    }
 


### PR DESCRIPTION
Dynamic imports from `import(...)` are not listed under a modules dependencies. This pull request solves this.

I wasn't able to figure out how to test it. You may have to add the tests yourself.